### PR TITLE
fix error on meta learn function

### DIFF
--- a/lightning_mtl.py
+++ b/lightning_mtl.py
@@ -184,9 +184,10 @@ class LightningMTL(LightningEpisodicModule):
         assert weight.shape == self.classifier.weight.shape
         def learner(x):
             return F.linear(x, weight)
-        for i, class_idx in enumerate(class_idxes):
-            labels[labels == class_idx] = i
+        labels_new = torch.zeros_like(labels).long()
+        for i, class_idx in enumerate(class_idxes):            
+            labels_new[labels == class_idx] = i        
         preds = learner(self.features(data))
-        error = self.loss(preds, labels)
-        acc = accuracy(preds, labels)
+        error = self.loss(preds, labels_new)
+        acc = accuracy(preds, labels_new)
         return error,acc


### PR DESCRIPTION
First, thanks for making your code public. It was very helpful.

I just found very minor error in meta_learn function of lightning_mtl.py.

If "labels" of incoming batch is sampled as 
       [26., 26., 26., 26., 26., 26., 26., 26., 26., 26., 
         0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0., 
        15., 15., 15., 15., 15., 15., 15., 15., 15., 15.,
        37., 37., 37., 37., 37., 37., 37., 37., 37., 37.,
        47., 47., 47., 47., 47., 47., 47., 47., 47., 47.]

new label for multi task learning is changed as
       [ 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 
         1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
         2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
         3,  3,  3,  3,  3,  3,  3,  3,  3,  3,
         4,  4,  4,  4,  4,  4,  4,  4,  4,  4]

Because after "26" label(1st row) is changed to new "0" label(1st row),
 then "0" labels(both of 1st row, 2nd row) are changed to new "1" label.

So to avoid this less likely situation, I made a labels_new tensor.

Thank you.    



